### PR TITLE
PDF -> image-byte-stream for use with `with-images` function

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,9 @@
         de.kherud/llama {:mvn/version "3.0.1"}
         me.tongfei/progressbar {:mvn/version "0.10.0"}
         com.hubspot.jinjava/jinjava {:mvn/version "2.7.2"}
-        org.apache.tika/tika-core {:mvn/version "2.9.2"}}
+        org.apache.tika/tika-core {:mvn/version "2.9.2"}
+        org.apache.pdfbox/pdfbox {:mvn/version "2.0.31"}
+        org.apache.pdfbox/pdfbox-tools {:mvn/version "2.0.31"}}
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
                  slipset/deps-deploy {:mvn/version "0.2.1"}}

--- a/src/ragtacts/loader/doc.clj
+++ b/src/ragtacts/loader/doc.clj
@@ -3,7 +3,57 @@
             [clojure.java.io :as io]
             [clojure.string :as str])
   (:import [dev.langchain4j.data.document Document DocumentParser]
-           [dev.langchain4j.data.document.parser.apache.tika ApacheTikaDocumentParser]))
+           [dev.langchain4j.data.document.parser.apache.tika ApacheTikaDocumentParser]
+           [org.apache.pdfbox.pdmodel PDDocument]
+           [org.apache.pdfbox.rendering PDFRenderer]
+           [org.apache.pdfbox.rendering ImageType]
+           [org.apache.pdfbox.tools.imageio ImageIOUtil]
+           (java.io ByteArrayOutputStream)))
+
+
+(defn- range-intersection-for-border-pairs
+  [range-border-pairs]
+  (let [intersection-vec (reduce
+                          (fn [[start1 end1] [start2 end2]]
+                            [(max start1 start2) (min end1 end2)])
+                          (first range-border-pairs)
+                          (rest range-border-pairs))]
+    (range (first intersection-vec)
+           (last intersection-vec))))
+
+(defn- image->byte-array
+  [{image :image ext :ext dpi :dpi}]
+  (let [baos (ByteArrayOutputStream.)]
+    (try
+      (ImageIOUtil/writeImage image ext baos dpi)
+      (.flush baos)
+      (.toByteArray baos)
+      (finally
+        (when (not= baos nil) (.close baos))))))
+
+(defn- pdf-to-images-byte-array-list
+  [pdf-file {:keys [start-page end-page dpi ext]}]
+  (let [pd-document (PDDocument/load pdf-file)
+        pdf-renderer (PDFRenderer. pd-document)
+        pages (vec (.getPages pd-document))
+        page-range (range-intersection-for-border-pairs [[0 (count pages)]
+                                                         [start-page end-page]])]
+
+    (try
+      (doall
+       (map
+        (fn [page-index]
+          (let [image (.renderImageWithDPI pdf-renderer page-index dpi ImageType/RGB)]
+            (image->byte-array {:image image
+                                :image-index page-index
+                                :ext ext
+                                :dpi dpi
+                                :base-path (.getAbsolutePath pdf-file)})))
+        page-range))
+      (finally
+        (if (not= pd-document nil)
+          (.close pd-document)
+          (print "No PDF document to close"))))))
 
 (defn get-text
   "Return the text of a document. PDF, DOCX, and other formats are supported.
@@ -33,3 +83,23 @@
 
 (defn stop-watch [pool]
   (throw (ex-info "Not implemented" {})))
+
+(defn get-images-from-pdf
+  "Return the image's byte-array list of a documnet.PDF supported.
+  Args:
+  - pdf-file-path: A string with the path of the pdf file.
+  - options: A map with the following keys
+   - `:start-page`: A start page of the pdf file. (default 0)
+   - `:end-page`: A last page of the pdf file. (default Integer/MAX_VALUE)
+   - `dpi`: A number of dots that fit horizontally and vertically into a one-inch length. (default 300)
+   - `ext`: A string with the extension of the image.(default 'png')"
+  [pdf-file-path & {:keys [start-page end-page dpi ext]
+                    :or {start-page 0
+                         end-page Integer/MAX_VALUE
+                         dpi 300
+                         ext "png"}}]
+  (pdf-to-images-byte-array-list (clojure.java.io/file pdf-file-path)
+                                 {:start-page start-page
+                                  :end-page end-page
+                                  :dpi dpi
+                                  :ext ext}))


### PR DESCRIPTION
PDF files that are difficult to parse can be converted to images and used with the `with-images` function.


```clojure
(let [image-input-streams (doc/get-images-from-pdf "/path/filname.pdf" :start-page 2 :end-page 5)
        image-texts (map (fn [image-input-stream]
                           (-> (ask (with-images "Please provide the contents of the following table." (io/input-stream image-input-stream)))
                               last
                               :ai))
                         image-input-streams)]
    image-texts)
   ```