### PR TITLE
Modified PDF page parameters for ease of use

### DIFF
--- a/src/ragtacts/loader/doc.clj
+++ b/src/ragtacts/loader/doc.clj
@@ -33,12 +33,13 @@
 
 (defn- pdf-to-images-byte-array-list
   [pdf-file {:keys [start-page end-page dpi ext]}]
-  (let [pd-document (PDDocument/load pdf-file)
+  (let [real-start-page (dec start-page)
+        real-end-page end-page
+        pd-document (PDDocument/load pdf-file)
         pdf-renderer (PDFRenderer. pd-document)
         pages (vec (.getPages pd-document))
         page-range (range-intersection-for-border-pairs [[0 (count pages)]
-                                                         [start-page end-page]])]
-
+                                                         [real-start-page real-end-page]])]
     (try
       (doall
        (map


### PR DESCRIPTION
In the previous code, the pages started from 0, but the current code reflects the actual pages of the PDF. 
Additionally, in the previous code, the `end-page` was not included, whereas in the current code, it is included.

Thus, the modified code operates as follows:
If `start-page` is 1 and `end-page` is 2, it converts pages [1, 2] to images.