### PR TITLE
Allow conditional filtering of vector databses

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,22 @@ retrieved can be changed using the `top-k` option value.
 ;;  model.")
 ```
 
+You can search multiple vector databases by supplying them in a vector to the `search` function
+
+```clojure
+(let [db1 (vector-store)
+      db2 (vector-store)]
+  (add db1 ["The new data outside of the LLM's original training data set is called external data."
+            "What Is RAG?"
+            "The next question may be—what if the external data becomes stale?"])
+  (add db2 ["Retrieval-Augmented Generation (RAG) is the process of optimizing the output of a large language model."
+            "The next step is to perform a relevancy search."
+            "Recursive summarization as Context Summarization techniques provide a condensed view of documents"])
+  (search [db1 db2] "Tell me about RAG"))
+;; ("Retrieval-Augmented Generation (RAG) is the process of optimizing the output of a large language model."
+;; "What Is ...")
+```
+
 You can include additional information along with the documents to be stored as vectors, and filter 
 your search results using this additional information.
 
@@ -245,6 +261,25 @@ your search results using this additional information.
 The `"What Is RAG?"` was most similar to `"Tell me about RAG"`, but since the search was filtered 
 to only include documents with `metadata` where the `topic` is `"Tutorial"`, `"What Is RAG?"` 
 did not appear in the results.
+
+You can specify a conditional filter by providing a vector containing the operator and the value. The available operators are `>`, `>=`, `<`, `<=`, `not`, `in` and `not-in`.
+
+``` clojure
+(let [db (vector-store)]
+      (add db [{:text "Bird" :metadata {:legs 2}}
+               {:text "Cat" :metadata {:legs 4}}
+               {:text "Octopus" :metadata {:legs 8}}])
+      [(search db "anything" {:metadata {:legs 8}})
+       (search db "anything" {:metadata {:legs [:< 8]}})
+       (search db "anything" {:metadata {:legs [:<= 8]}})
+       (search db "anything" {:metadata {:legs [:> 4]}})
+       (search db "anything" {:metadata {:legs [:>= 4]}})
+       (search db "anything" {:metadata {:legs [:not 8]}})
+       (search db "anything" {:metadata {:legs [:in (range 3)]}})
+       (search db "anything" {:metadata {:legs [:not-in #{3 4 5}]}})])
+;; [("Octopus") ("Cat" "Bird") ("Cat" "Bird" "Octopus") ("Octopus") ("Cat" "Octopus") ("Cat" "Bird")
+;; ("Bird") ("Bird" "Octopus")]
+```
 
 If you add the `{:raw? true}` option to the `search` function, you can retrieve the stored vector 
 values and metadata in the result.

--- a/test/ragtacts/core_test.clj
+++ b/test/ragtacts/core_test.clj
@@ -77,10 +77,31 @@
                {:text "B" :metadata {:animal "cat"}}])
       (is (= (search db "A" {:metadata {:animal "dog"}}) ["A"]))))
 
+  (testing "Search with conditional filtering"
+    (let [db (vector-store)]
+      (add db [{:text "Bird" :metadata {:legs 2}}
+               {:text "Cat" :metadata {:legs 4}}
+               {:text "Octopus" :metadata {:legs 8}}])
+      (is (= ["Octopus"]
+             (search db "anything" {:metadata {:legs 8}})))
+      (is (= (set ["Bird" "Cat"])
+             (set (search db "anything" {:metadata {:legs [:< 8]}}))))
+      (is (= (set ["Bird" "Cat" "Octopus"])
+             (set (search db "anything" {:metadata {:legs [:<= 8]}}))))
+      (is (= (set ["Octopus"])
+             (set (search db "anything" {:metadata {:legs [:> 4]}}))))
+      (is (= (set ["Cat" "Octopus"])
+             (set (search db "anything" {:metadata {:legs [:>= 4]}}))))
+      (is (= (set ["Bird" "Cat"])
+             (set (search db "anything" {:metadata {:legs [:not 8]}}))))
+      (is (= (set ["Bird"])
+             (set (search db "anything" {:metadata {:legs [:in (range 3)]}}))))
+      (is (= (set ["Bird" "Octopus"])
+             (set (search db "anything" {:metadata {:legs [:not-in #{3 4 5}]}}))))))
+
   (testing "Seach multiple vector stores"
     (let [db1 (vector-store)
           db2 (vector-store)]
       (add db1 ["A" "B"])
       (add db2 ["A" "B"])
       (is (= (search [db1 db2] "A") ["A" "A" "B" "B"])))))
-      


### PR DESCRIPTION
Fixes #7

This change allows the user to specify filters in `:metadata` while calling the `search` function on a vector database.

A vector of `[:<operator> <value>]` can be supplied in place of a single `<value>`.

```
;; simple filter (implcit `.isEqualTo`)
{:metadata {:legs 8}}

;; conditional filter
{:metadata {:legs [:< 8]}}
```