### PR TITLE
Allow custom tags for templates

### DIFF
--- a/test/ragtacts/util_test.clj
+++ b/test/ragtacts/util_test.clj
@@ -16,4 +16,12 @@
   (is (= "{x}"
          (f-string "{{a}}" {:a "x"})))
   (is (= "{{{x} {y}}}"
-         (f-string "{{{{a}} {{b}}}}" {:a "x" :b "y"}))))
+         (f-string "{{{{a}} {{b}}}}" {:a "x" :b "y"})))
+  (is (= "{:foo bar}"
+         (f-string "{:foo <x>}" {:x "bar"
+                                 :tag-open "<"
+                                 :tag-close ">"})))
+  (is (= "{:foo bar}"
+         (f-string "{:foo {{x}}}" {:x "bar"
+                                   :tag-open "{{"
+                                   :tag-close "}}"}))))


### PR DESCRIPTION
Fixes #27 

Sometimes when writing aa prompt template you might want to include braces without it being interpreted as a variable (e.g. a code example with a Clojure map `{:foo {x}}`) this change allows you to specify custom tag delimiters so they don't get confused for the map literal (e.g. `{:foo <x>}`)